### PR TITLE
Add prisma prisma

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,3 +8,71 @@ datasource db {
   url       = env("POSTGRES_PRISMA_URL") // uses connection pooling
   directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
 }
+
+model User {
+  id            String    @id @default(cuid())
+  name          String?
+  email         String    @unique
+  emailVerified DateTime?
+  image         String?
+  role          String?
+  accounts      Account[]
+  sessions      Session[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("users")
+}
+
+model Account {
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?
+  access_token      String?
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?
+  session_state     String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([provider, providerAccountId])
+  @@map("accounts")
+}
+
+model Session {
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("sessions")
+}
+
+model VerificationToken {
+  identifier String
+  token      String
+  expires    DateTime
+
+  @@id([identifier, token])
+  @@map("verification_tokens")
+}
+
+model ResetPasswordToken {
+  identifier String
+  token      String
+  expires    DateTime
+
+  @@id([identifier, token])
+  @@map("reset_password_tokens")
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
-import NavBar from "@/components/NavBar";
+import Navbar from "@/components/Navbar";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -23,7 +23,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <NavBar />
+        <Navbar />
         {children}
         <Toaster />
       </body>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-export default function NavBar() {
+export default function Navbar() {
   // TODO: Show the currently logged-in user
 
   return (

--- a/src/components/SettingsForm.tsx
+++ b/src/components/SettingsForm.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/use-toast";
-import { UpdateProfileValues, updateProfileSchema } from "@/lib/validation";
+import { UpdateProfileValues, updateProfileSchema } from "@/schemas/index";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { updateProfile } from "@/actions/updateProfile";

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,8 +1,11 @@
 import { PrismaClient } from "@prisma/client";
+import { Pool } from "@neondatabase/serverless";
+import { PrismaNeon } from "@prisma/adapter-neon";
 
 const prismaClientSingleton = () => {
-  // TODO: Make this edge-compatible
-  return new PrismaClient();
+  const neon = new Pool({ connectionString: process.env.POSTGRES_PRISMA_URL });
+  const adapter = new PrismaNeon(neon);
+  return new PrismaClient({ adapter });
 };
 
 declare global {

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,7 +1,10 @@
 import { z } from "zod";
 
+// Schema for updating a user's name in their profile
 export const updateProfileSchema = z.object({
   name: z.string().trim().min(1, "Cannot be empty"),
 });
 
+// Type for the values that can be passed to the updateProfileSchema
 export type UpdateProfileValues = z.infer<typeof updateProfileSchema>;
+


### PR DESCRIPTION
## Summary
Added prisma schema models for users, such as `User` (for cred login/signup etc.), `Account` (for github sign-ins & google sign-ins), `Session` (to manage sessions through the database) , `VerificationToken`, `PasswordResetToken`

Refactored the schemas for form validations, moved the validation.ts to an index.ts inside a schema folder for future form validations (for creating accounts through credentials or login in with credentials), keeps the folder structure more modular.