### PR TITLE
Updated forgot password flow to replace old reset tokens

### DIFF
--- a/src/actions/auth/forgot-password.ts
+++ b/src/actions/auth/forgot-password.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import prisma from "@/lib/prisma";
 import { z } from "zod";
 import { ForgotPasswordFormSchema } from "@/schemas";
 import { getUserByEmail } from "@/utils/user";
@@ -27,8 +28,13 @@ export const forgotPassword = async (data: z.infer<typeof ForgotPasswordFormSche
       return { error: "User not found" };
     }
 
+    // Invalidate all the existing password reset tokens
+    await prisma.resetPasswordToken.deleteMany({
+      where: { identifier: email },
+    });
+
     // Generate a password reset token
-    const resetToken = await generatePasswordResetToken();
+    const resetToken = await generatePasswordResetToken(email);
 
     // Send the password reset email to the user
     await sendPasswordResetEmail(email, resetToken);

--- a/src/components/emails/ForgotPassword.tsx
+++ b/src/components/emails/ForgotPassword.tsx
@@ -24,7 +24,7 @@ export default function ForgotPassword({
   return (
     <Html>
       <Head />
-      <Preview>Dropbox reset your password</Preview>
+      <Preview>Reset your password</Preview>
       <Body style={main}>
         <Container style={container}>
           <Section>

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,6 +1,5 @@
 import prisma from "@/lib/prisma";
 import crypto from "crypto";
-import { getUserByEmail } from "./user";
 
 // Function to generate a 6-digit numeric OTP
 const generateNumericOTP = (): string => {
@@ -63,13 +62,13 @@ export const deleteVerificationToken = async (email: string, token: string) => {
 };
 
 // Generate password reset token 
-export const generatePasswordResetToken = async (): Promise<string> => {
+export const generatePasswordResetToken = async (email: string): Promise<string> => {
   const resetToken = crypto.randomBytes(32).toString("hex");
   const expires = new Date().getTime() + 1000 * 60 * 10;
 
   await prisma.resetPasswordToken.create({
     data: {
-      identifier: resetToken,
+      identifier: email,
       token: resetToken,
       expires: new Date(expires),
     },


### PR DESCRIPTION
## Description
This PR updates the forgot password flow to ensure that old password reset tokens are replaced with new ones when a user requests a password reset.

## Changes
1. **Forgot Password Flow**:
    - Modified the `forgotPassword` server action to delete any existing password reset tokens before generating a new one.
    - Updated the `generatePasswordResetToken` function to take the user's email and save the new token with the associated email.

## How to Test
1. **Request Password Reset**:
    - Navigate to the forgot password page and request a password reset for an existing user. Verify that a password reset email is received.
2. **Request Again**:
    - Immediately request another password reset for the same user. Ensure that the new reset token replaces the old one in the database.
3. **Expired Token**:
    - Test to ensure that after 10 minutes, the reset token expires and cannot be used to reset the password.